### PR TITLE
feat: 키보드 동작 트리거를 위한 custom event

### DIFF
--- a/src/components/Keyboard/Key/index.tsx
+++ b/src/components/Keyboard/Key/index.tsx
@@ -1,10 +1,11 @@
 import { ThreeEvent, useFrame } from '@react-three/fiber'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import KeyCap from './KeyCap'
 import KeyLegend from './KeyLegend'
 import { IkeyConfig } from '../../../types/KeyboardType'
 import { KEY_DOWN_DURATION, KEY_DOWN_POSITION } from './consts'
 import { Howl } from 'howler'
+import { ThreeEventType } from '../../../types/ThreeEvent'
 
 type KeyProps = { keyConfig: IkeyConfig }
 
@@ -13,19 +14,31 @@ export default (props: KeyProps) => {
   const [keyDownPosition, setKeyDownPosition] = useState<number>(0)
   const howl = useRef<Howl>(new Howl({ src: 'sample_audio.ogg' }))
 
+  useEffect(() => {
+    document.addEventListener('threekeyboardevent', keyboardEventHander)
+
+    return () => {
+      document.removeEventListener('threekeyboardevent', keyboardEventHander)
+    }
+  }, [])
+
   useFrame(() => {
     keyDownPosition < 0 &&
       setKeyDownPosition((prev) => prev + KEY_DOWN_DURATION)
   })
 
-  const onKeyClick = (evt: ThreeEvent<MouseEvent>) => {
-    evt.stopPropagation()
+  const onKeyClick = (evt?: ThreeEvent<MouseEvent>) => {
+    evt?.stopPropagation()
     setKeyDownPosition(KEY_DOWN_POSITION)
     howl.current?.play()
   }
 
+  const keyboardEventHander = (evt: CustomEvent<ThreeEventType>) => {
+    if (evt.detail?.keyId === keyConfig.legend?.text.toLowerCase()) onKeyClick()
+  }
+
   return (
-    <group onClick={onKeyClick} position={[0, keyDownPosition, 0]}>
+    <group position={[0, keyDownPosition, 0]}>
       <KeyCap
         config={keyConfig}
         position={[keyConfig.column, 0, keyConfig.row]}

--- a/src/components/Keyboard/Key/index.tsx
+++ b/src/components/Keyboard/Key/index.tsx
@@ -50,3 +50,17 @@ export default (props: KeyProps) => {
     </group>
   )
 }
+
+export const genCustomKeyEventFromCharacter = (
+  char: string,
+): CustomEvent<ThreeEventType> => {
+  if (char.length !== 1) {
+    throw new Error(
+      `Invalid input for custom key event. Input should be single charater. Input is ${char}, though.`,
+    )
+  }
+
+  return new CustomEvent<ThreeEventType>('threekeyboardevent', {
+    detail: { keyId: char.toLowerCase() },
+  })
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './App'
+import { genCustomKeyEventFromCharacter } from './components/Keyboard/Key'
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(<App />)
+
+document.addEventListener('keydown', (evt) => {
+  const event = genCustomKeyEventFromCharacter(evt.key)
+  document.dispatchEvent(event)
+})

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,7 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import "./index.css";
-import App from "./App";
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import './index.css'
+import App from './App'
 
-const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
-);
-root.render(<App />);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+root.render(<App />)

--- a/src/types/ThreeEvent.d.ts
+++ b/src/types/ThreeEvent.d.ts
@@ -1,0 +1,24 @@
+export type ThreeEventType = {
+  keyId?: string
+}
+
+interface ThreeCustomEvent {
+  threekeyboardevent: CustomEvent<ThreeEventType>
+}
+declare global {
+  interface Document {
+    //adds definition to Document, but you can do the same with HTMLElement
+    addEventListener<K extends keyof ThreeCustomEvent>(
+      type: K,
+      listener: (this: Document, ev: ThreeCustomEvent[K]) => void,
+    ): void
+    removeEventListener<K extends keyof ThreeCustomEvent>(
+      type: K,
+      listener: (this: Document, ev: ThreeCustomEvent[K]) => void,
+    ): void
+    dispatchEvent<K extends keyof ThreeCustomEvent>(
+      ev: ThreeCustomEvent[K],
+    ): void
+  }
+}
+export {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "typeRoots": ["src/types/ThreeEvent"]
   },
   "include": [
     "src"


### PR DESCRIPTION
## overview
document에 dispatch 할 수 있는 custom event를 선언하고,
해당 custom event에 대한 핸들러를 구현했습니다.

이해를 돕기 위해서 데모 용도의 코드를 추가했습니다.
키보드 입력에 대응하는 키가 눌리도록 ("a" 키 누르면 "A"에 해당하는 키보드 매쉬가 움직이면서 소리나도록) 작업해두었습니다.
`index.tsx`에 `addEventListener` 참고해주세요.




https://user-images.githubusercontent.com/9066602/220371854-5ca60209-aba6-4a08-861f-acd0133a2691.mov



[사이트](https://d5803e34.febase4-3d-team1.pages.dev/)에 접속해서 키보드 a 와 s 눌러보시길 바랍니다.

## detail
- custom event를 대해 선언해주려고 298ac74d3266debfae0da48651c815a5ba6ab0eb 에서 `document`에 `ThreeEventType`과 `ThreeCustomEvent`를 선언했습니다. (좋은 이름 추천해줘도 좋겠습니다. `ThreeEvent` 이름은 이미 `@react-three/fiber`에게 선점당했어요.

- 위의 커스텀 이벤트 선언을 통해 `document.addEventListener('threekeyboardevent', keyboardEventHander)`처럼 이벤트핸들러 바인딩이 가능합니다.
298ac74d3266debfae0da48651c815a5ba6ab0eb 의 src/components/Keyboard/Key/index.tsx 를 봐주세요. 

- 커스텀 이벤트 생성을 돕고자 helper function 추가했습니다. 38c90ac9a28c455589d0002d095af06f0ec8c02d 에서 추가한 `genCustomKeyEventFromCharacter` 이름의 함수를 확인해주세요.

- 38c90ac9a28c455589d0002d095af06f0ec8c02d 에서 데모 용도의 document의 keydown 이벤트 리스너를 등록했습니다. 키보드 움직임+소리 재생 기능을 원할 땐 해당 방식으로 호출하면 됩니다.


